### PR TITLE
Convert admissionregistration/v1beta1 to v1

### DIFF
--- a/cmd/patch.go
+++ b/cmd/patch.go
@@ -6,7 +6,7 @@ import (
 	"github.com/jet/kube-webhook-certgen/pkg/k8s"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	admissionv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	admissionv1 "k8s.io/api/admissionregistration/v1"
 )
 
 var (
@@ -29,7 +29,7 @@ func prePatchCommand(cmd *cobra.Command, args []string) {
 		break
 	case "Ignore":
 	case "Fail":
-		failurePolicy = admissionv1beta1.FailurePolicyType(cfg.patchFailurePolicy)
+		failurePolicy = admissionv1.FailurePolicyType(cfg.patchFailurePolicy)
 		break
 	default:
 		log.Fatalf("patch-failure-policy %s is not valid", cfg.patchFailurePolicy)
@@ -45,7 +45,7 @@ func patchCommand(_ *cobra.Command, _ []string) {
 		log.Fatalf("no secret with '%s' in '%s'", cfg.secretName, cfg.namespace)
 	}
 
-	log.Println("config= %#v", cfg)
+	log.Printf("config= %#v", cfg)
 	k.PatchWebhookConfigurations(cfg.webhookName, ca, &failurePolicy, cfg.patchMutating, cfg.patchValidating, cfg.namespace, cfg.crds)
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,7 +6,7 @@ import (
 	"github.com/onrik/logrus/filename"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	admissionv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	admissionv1 "k8s.io/api/admissionregistration/v1"
 )
 
 var (
@@ -35,7 +35,7 @@ var (
 		crds               []string
 	}{}
 
-	failurePolicy admissionv1beta1.FailurePolicyType
+	failurePolicy admissionv1.FailurePolicyType
 )
 
 // Execute is the main entry point for the program

--- a/pkg/k8s/k8s.go
+++ b/pkg/k8s/k8s.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	log "github.com/sirupsen/logrus"
-	admissionv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	admissionv1 "k8s.io/api/admissionregistration/v1"
 	v1 "k8s.io/api/core/v1"
 	crdv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -55,14 +55,14 @@ func New(kubeconfig string) *k8s {
 // the provided ca data. If failurePolicy is provided, patch all webhooks with this value
 func (k8s *k8s) PatchWebhookConfigurations(
 	configurationNames string, ca []byte,
-	failurePolicy *admissionv1beta1.FailurePolicyType,
+	failurePolicy *admissionv1.FailurePolicyType,
 	patchMutating bool, patchValidating bool, patchNamespace string, crds []string) {
 
 	log.Infof("patching webhook configurations '%s' mutating=%t, validating=%t, failurePolicy=%s", configurationNames, patchMutating, patchValidating, *failurePolicy)
 
 	if patchValidating {
 		valHook, err := k8s.clientset.
-			AdmissionregistrationV1beta1().
+			AdmissionregistrationV1().
 			ValidatingWebhookConfigurations().
 			Get(context.TODO(), configurationNames, metav1.GetOptions{})
 
@@ -78,7 +78,7 @@ func (k8s *k8s) PatchWebhookConfigurations(
 			}
 		}
 
-		if _, err = k8s.clientset.AdmissionregistrationV1beta1().
+		if _, err = k8s.clientset.AdmissionregistrationV1().
 			ValidatingWebhookConfigurations().
 			Update(context.TODO(), valHook, metav1.UpdateOptions{}); err != nil {
 			log.WithField("err", err).Fatal("failed patching validating webhook")
@@ -90,7 +90,7 @@ func (k8s *k8s) PatchWebhookConfigurations(
 
 	if patchMutating {
 		mutHook, err := k8s.clientset.
-			AdmissionregistrationV1beta1().
+			AdmissionregistrationV1().
 			MutatingWebhookConfigurations().
 			Get(context.TODO(), configurationNames, metav1.GetOptions{})
 		if err != nil {
@@ -105,7 +105,7 @@ func (k8s *k8s) PatchWebhookConfigurations(
 			}
 		}
 
-		if _, err = k8s.clientset.AdmissionregistrationV1beta1().
+		if _, err = k8s.clientset.AdmissionregistrationV1().
 			MutatingWebhookConfigurations().
 			Update(context.TODO(), mutHook, metav1.UpdateOptions{}); err != nil {
 			log.WithField("err", err).Fatal("failed patching validating webhook")

--- a/pkg/k8s/k8s_test.go
+++ b/pkg/k8s/k8s_test.go
@@ -8,9 +8,8 @@ import (
 	"testing"
 
 	log "github.com/sirupsen/logrus"
-	"k8s.io/api/admissionregistration/v1beta1"
-	admissionv1beta1 "k8s.io/api/admissionregistration/v1beta1"
-	"k8s.io/api/core/v1"
+	admissionv1 "k8s.io/api/admissionregistration/v1"
+	v1 "k8s.io/api/core/v1"
 	crdv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
@@ -29,8 +28,8 @@ const (
 )
 
 var (
-	fail   = admissionv1beta1.Fail
-	ignore = admissionv1beta1.Ignore
+	fail   = admissionv1.Fail
+	ignore = admissionv1.Ignore
 )
 
 func genSecretData() (ca, cert, key []byte) {
@@ -106,29 +105,29 @@ func TestPatchWebhookConfigurations(t *testing.T) {
 	ca, _, _ := genSecretData()
 
 	k.clientset.
-		AdmissionregistrationV1beta1().
+		AdmissionregistrationV1().
 		MutatingWebhookConfigurations().
-		Create(context.Background(), &v1beta1.MutatingWebhookConfiguration{
+		Create(context.Background(), &admissionv1.MutatingWebhookConfiguration{
 			TypeMeta: metav1.TypeMeta{},
 			ObjectMeta: metav1.ObjectMeta{
 				Name: testWebhookName,
 			},
-			Webhooks: []v1beta1.MutatingWebhook{{Name: "m1"}, {Name: "m2"}}}, metav1.CreateOptions{})
+			Webhooks: []admissionv1.MutatingWebhook{{Name: "m1"}, {Name: "m2"}}}, metav1.CreateOptions{})
 
 	k.clientset.
-		AdmissionregistrationV1beta1().
+		AdmissionregistrationV1().
 		ValidatingWebhookConfigurations().
-		Create(context.Background(), &v1beta1.ValidatingWebhookConfiguration{
+		Create(context.Background(), &admissionv1.ValidatingWebhookConfiguration{
 			TypeMeta: metav1.TypeMeta{},
 			ObjectMeta: metav1.ObjectMeta{
 				Name: testWebhookName,
 			},
-			Webhooks: []v1beta1.ValidatingWebhook{{Name: "v1"}, {Name: "v2"}}}, metav1.CreateOptions{})
+			Webhooks: []admissionv1.ValidatingWebhook{{Name: "v1"}, {Name: "v2"}}}, metav1.CreateOptions{})
 
 	// create crd step for fake client query
 	var crds []string
 	crds = append(crds, "applications.core.oam.dev")
-	PolicyType := admissionv1beta1.FailurePolicyType("ignore")
+	PolicyType := admissionv1.FailurePolicyType("ignore")
 	patchNamespace := "test-vela-ns"
 
 	var crdObjectByte []byte
@@ -164,7 +163,7 @@ func TestPatchWebhookConfigurations(t *testing.T) {
 	}
 
 	whmut, err := k.clientset.
-		AdmissionregistrationV1beta1().
+		AdmissionregistrationV1().
 		MutatingWebhookConfigurations().
 		Get(context.Background(), testWebhookName, metav1.GetOptions{})
 
@@ -173,7 +172,7 @@ func TestPatchWebhookConfigurations(t *testing.T) {
 	}
 
 	whval, err := k.clientset.
-		AdmissionregistrationV1beta1().
+		AdmissionregistrationV1().
 		MutatingWebhookConfigurations().
 		Get(context.Background(), testWebhookName, metav1.GetOptions{})
 


### PR DESCRIPTION
Upgrades `kube-webhook-certgen` to use `admissionregistration/v1` instead of `v1beta1`, which is no longer supported in Kubernetes 1.22+.

Without this, the patch job fails with the following message:

```
W0906 00:52:23.151303       1 client_config.go:615] Neither --kubeconfig nor --master was specified.  Using the inClusterConfig.  This might not work.
{"level":"error","msg":"config= struct { logLevel string; logfmt string; secretName string; namespace string; certName string; keyName string; host string; webhookName string; patchValidating bool; patchMutating bool; patchFailurePolicy string; kubeconfig string; crds []string }{logLevel:\"info\", logfmt:\"json\", secretName:\"kubevela-vela-core-admission\", namespace:\"vela-system\", certName:\"cert\", keyName:\"key\", host:\"\", webhookName:\"kubevela-vela-core-admission\", patchValidating:true, patchMutating:true, patchFailurePolicy:\"Fail\", kubeconfig:\"\", crds:[]string{\"applications.core.oam.dev\"}}","source":"cmd/patch.go:47","time":"2021-09-06T00:52:23Z"}
{"level":"info","msg":"patching webhook configurations 'kubevela-vela-core-admission' mutating=true, validating=true, failurePolicy=Fail","source":"k8s/k8s.go:59","time":"2021-09-06T00:52:23Z"}
{"err":"the server could not find the requested resource","level":"fatal","msg":"failed getting validating webhook","source":"k8s/k8s.go:68","time":"2021-09-06T00:52:23Z"}
``` 