### PR TITLE
Feat: update admissionregistration version from v1beta1 to v1

### DIFF
--- a/cmd/patch.go
+++ b/cmd/patch.go
@@ -6,7 +6,7 @@ import (
 	"github.com/jet/kube-webhook-certgen/pkg/k8s"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	admissionv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	admissionv1 "k8s.io/api/admissionregistration/v1"
 )
 
 var (
@@ -29,7 +29,7 @@ func prePatchCommand(cmd *cobra.Command, args []string) {
 		break
 	case "Ignore":
 	case "Fail":
-		failurePolicy = admissionv1beta1.FailurePolicyType(cfg.patchFailurePolicy)
+		failurePolicy = admissionv1.FailurePolicyType(cfg.patchFailurePolicy)
 		break
 	default:
 		log.Fatalf("patch-failure-policy %s is not valid", cfg.patchFailurePolicy)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,10 +3,10 @@ package cmd
 import (
 	"os"
 
+	admissionv1 "k8s.io/api/admissionregistration/v1"
 	"github.com/onrik/logrus/filename"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	admissionv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 )
 
 var (
@@ -35,7 +35,7 @@ var (
 		crds               []string
 	}{}
 
-	failurePolicy admissionv1beta1.FailurePolicyType
+	failurePolicy admissionv1.FailurePolicyType
 )
 
 // Execute is the main entry point for the program

--- a/pkg/k8s/k8s.go
+++ b/pkg/k8s/k8s.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	log "github.com/sirupsen/logrus"
-	admissionv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	admissionv1 "k8s.io/api/admissionregistration/v1"
 	v1 "k8s.io/api/core/v1"
 	crdv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -55,14 +55,14 @@ func New(kubeconfig string) *k8s {
 // the provided ca data. If failurePolicy is provided, patch all webhooks with this value
 func (k8s *k8s) PatchWebhookConfigurations(
 	configurationNames string, ca []byte,
-	failurePolicy *admissionv1beta1.FailurePolicyType,
+	failurePolicy *admissionv1.FailurePolicyType,
 	patchMutating bool, patchValidating bool, patchNamespace string, crds []string) {
 
 	log.Infof("patching webhook configurations '%s' mutating=%t, validating=%t, failurePolicy=%s", configurationNames, patchMutating, patchValidating, *failurePolicy)
 
 	if patchValidating {
 		valHook, err := k8s.clientset.
-			AdmissionregistrationV1beta1().
+			AdmissionregistrationV1().
 			ValidatingWebhookConfigurations().
 			Get(context.TODO(), configurationNames, metav1.GetOptions{})
 
@@ -78,7 +78,7 @@ func (k8s *k8s) PatchWebhookConfigurations(
 			}
 		}
 
-		if _, err = k8s.clientset.AdmissionregistrationV1beta1().
+		if _, err = k8s.clientset.AdmissionregistrationV1().
 			ValidatingWebhookConfigurations().
 			Update(context.TODO(), valHook, metav1.UpdateOptions{}); err != nil {
 			log.WithField("err", err).Fatal("failed patching validating webhook")
@@ -90,7 +90,7 @@ func (k8s *k8s) PatchWebhookConfigurations(
 
 	if patchMutating {
 		mutHook, err := k8s.clientset.
-			AdmissionregistrationV1beta1().
+			AdmissionregistrationV1().
 			MutatingWebhookConfigurations().
 			Get(context.TODO(), configurationNames, metav1.GetOptions{})
 		if err != nil {
@@ -105,7 +105,7 @@ func (k8s *k8s) PatchWebhookConfigurations(
 			}
 		}
 
-		if _, err = k8s.clientset.AdmissionregistrationV1beta1().
+		if _, err = k8s.clientset.AdmissionregistrationV1().
 			MutatingWebhookConfigurations().
 			Update(context.TODO(), mutHook, metav1.UpdateOptions{}); err != nil {
 			log.WithField("err", err).Fatal("failed patching validating webhook")

--- a/pkg/k8s/k8s_test.go
+++ b/pkg/k8s/k8s_test.go
@@ -8,8 +8,7 @@ import (
 	"testing"
 
 	log "github.com/sirupsen/logrus"
-	"k8s.io/api/admissionregistration/v1beta1"
-	admissionv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	admissionv1 "k8s.io/api/admissionregistration/v1"
 	"k8s.io/api/core/v1"
 	crdv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -29,8 +28,8 @@ const (
 )
 
 var (
-	fail   = admissionv1beta1.Fail
-	ignore = admissionv1beta1.Ignore
+	fail   = admissionv1.Fail
+	ignore = admissionv1.Ignore
 )
 
 func genSecretData() (ca, cert, key []byte) {
@@ -106,29 +105,29 @@ func TestPatchWebhookConfigurations(t *testing.T) {
 	ca, _, _ := genSecretData()
 
 	k.clientset.
-		AdmissionregistrationV1beta1().
+		AdmissionregistrationV1().
 		MutatingWebhookConfigurations().
-		Create(context.Background(), &v1beta1.MutatingWebhookConfiguration{
+		Create(context.Background(), &admissionv1.MutatingWebhookConfiguration{
 			TypeMeta: metav1.TypeMeta{},
 			ObjectMeta: metav1.ObjectMeta{
 				Name: testWebhookName,
 			},
-			Webhooks: []v1beta1.MutatingWebhook{{Name: "m1"}, {Name: "m2"}}}, metav1.CreateOptions{})
+			Webhooks: []admissionv1.MutatingWebhook{{Name: "m1"}, {Name: "m2"}}}, metav1.CreateOptions{})
 
 	k.clientset.
-		AdmissionregistrationV1beta1().
+		AdmissionregistrationV1().
 		ValidatingWebhookConfigurations().
-		Create(context.Background(), &v1beta1.ValidatingWebhookConfiguration{
+		Create(context.Background(), &admissionv1.ValidatingWebhookConfiguration{
 			TypeMeta: metav1.TypeMeta{},
 			ObjectMeta: metav1.ObjectMeta{
 				Name: testWebhookName,
 			},
-			Webhooks: []v1beta1.ValidatingWebhook{{Name: "v1"}, {Name: "v2"}}}, metav1.CreateOptions{})
+			Webhooks: []admissionv1.ValidatingWebhook{{Name: "v1"}, {Name: "v2"}}}, metav1.CreateOptions{})
 
 	// create crd step for fake client query
 	var crds []string
 	crds = append(crds, "applications.core.oam.dev")
-	PolicyType := admissionv1beta1.FailurePolicyType("ignore")
+	PolicyType := admissionv1.FailurePolicyType("ignore")
 	patchNamespace := "test-vela-ns"
 
 	var crdObjectByte []byte
@@ -164,7 +163,7 @@ func TestPatchWebhookConfigurations(t *testing.T) {
 	}
 
 	whmut, err := k.clientset.
-		AdmissionregistrationV1beta1().
+		AdmissionregistrationV1().
 		MutatingWebhookConfigurations().
 		Get(context.Background(), testWebhookName, metav1.GetOptions{})
 
@@ -173,7 +172,7 @@ func TestPatchWebhookConfigurations(t *testing.T) {
 	}
 
 	whval, err := k.clientset.
-		AdmissionregistrationV1beta1().
+		AdmissionregistrationV1().
 		MutatingWebhookConfigurations().
 		Get(context.Background(), testWebhookName, metav1.GetOptions{})
 


### PR DESCRIPTION
k8s v1.22 removes beta version of admissionregistration. refer to [k8s changelog](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.22.md#removal-of-several-beta-kubernetes-apis). so the `kube-webhook-certgen` will fail to patch webhook under k8s v1.22, It may cause the installation of kubevela via helm to fail.


